### PR TITLE
Improve UME performance (and fix compiling)

### DIFF
--- a/UME.as
+++ b/UME.as
@@ -8,15 +8,17 @@ class UMEGlacialMedal : UltimateMedalsExtended::IMedal {
         return c;
     }
     
+    bool hasMedal;
     string uid;
 
     void UpdateMedal(const string &in uid) override {
         this.uid = uid;
+        hasMedal = CampaignManager::glacial_campaign.MapExists(uid);
     }
 
     bool HasMedalTime(const string &in uid) override {
         if (uid != this.uid) {return false;}
-        return CampaignManager::glacial_campaign.MapExists(uid);
+        return hasMedal;
     }
 
     uint GetMedalTime() override {
@@ -33,15 +35,17 @@ class UMEChallengeMedal : UltimateMedalsExtended::IMedal {
         return c;
     }
 
+    bool hasMedal;
     string uid;
 
     void UpdateMedal(const string &in uid) override {
         this.uid = uid;
+        hasMedal = CampaignManager::glacial_campaign.MapExists(uid);
     }
 
     bool HasMedalTime(const string &in uid) override {
         if (uid != this.uid) {return false;}
-        return CampaignManager::glacial_campaign.MapExists(uid);
+        return hasMedal;
     }
 
     uint GetMedalTime() override {

--- a/UME.as
+++ b/UME.as
@@ -7,20 +7,20 @@ class UMEGlacialMedal : UltimateMedalsExtended::IMedal {
         c.icon = "\\$29b" + Icons::Circle;
         return c;
     }
+    
+    string uid;
 
-    void UpdateMedal(const string &in uid) override {}
+    void UpdateMedal(const string &in uid) override {
+        this.uid = uid;
+    }
 
     bool HasMedalTime(const string &in uid) override {
+        if (uid != this.uid) {return false;}
         return CampaignManager::glacial_campaign.MapExists(uid);
     }
 
     uint GetMedalTime() override {
-        auto app = cast<CGameManiaPlanet>(GetApp());
-        if (app.RootMap is null)
-            return 0;
-
-        const string uid = app.RootMap.EdChallengeId;
-        Map@ map = CampaignManager::glacial_campaign.GetMapByUid(uid);
+        Map@ map = CampaignManager::glacial_campaign.GetMapByUid(this.uid);
         return map.GetMedalTime(MedalType::Glacial);
     }
 }
@@ -33,19 +33,19 @@ class UMEChallengeMedal : UltimateMedalsExtended::IMedal {
         return c;
     }
 
-    void UpdateMedal(const string &in uid) override {}
+    string uid;
+
+    void UpdateMedal(const string &in uid) override {
+        this.uid = uid;
+    }
 
     bool HasMedalTime(const string &in uid) override {
+        if (uid != this.uid) {return false;}
         return CampaignManager::glacial_campaign.MapExists(uid);
     }
 
     uint GetMedalTime() override {
-        auto app = cast<CGameManiaPlanet>(GetApp());
-        if (app.RootMap is null)
-            return 0;
-
-        const string uid = app.RootMap.EdChallengeId;
-        Map@ map = CampaignManager::glacial_campaign.GetMapByUid(uid);
+        Map@ map = CampaignManager::glacial_campaign.GetMapByUid(this.uid);
         return map.GetMedalTime(MedalType::Challenge);
     }
 }

--- a/main.as
+++ b/main.as
@@ -14,7 +14,9 @@ void Main()
     while (!NadeoServices::IsAuthenticated("NadeoServices")) yield();
 
 	@browser = Browser();
+#if DEPENDENCY_ULTIMATEMEDALSEXTENDED
 	RegisterUME();
+#endif
 	startnew(Api::WatchForMapChange);
 }
 
@@ -39,6 +41,8 @@ void RenderMenu() {
 		browser.RenderMenu();
 }
 
+#if DEPENDENCY_ULTIMATEMEDALSEXTENDED
 void OnDestroyed() {
 	OnDestroyedUME();
 }
+#endif


### PR DESCRIPTION
- Fix the compilation errors when UME is not installed
- Improve performance of UME medals by caching uid (to avoid getting the uid from the current map)
- Improve performance of UME by caching hasMedals (to avoid dict lookup; since HasMedalTime is called every frame even on maps with nothing to do with glacial campaign)